### PR TITLE
Added Polygon3 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torchvision==0.2.1
 opencv-python==3.4.2.17
 scikit-image==0.14.2
 scipy==1.1.0
+Polygon3


### PR DESCRIPTION
Polygon3 is used but not in requirements.txt. Since Polygon3 is not the industry standard, it can be confusing to find how to install.